### PR TITLE
Hotfix/sweet32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- tls 1.3 is used as the default minimum version
+- only strong cipher suites are allowed for tls version less than 1.3
 
 ## [v0.3.0]
 - upgraded to httpaux v0.2.1


### PR DESCRIPTION
This makes tls 1.3 the default minimum version and enforces a subset of cipher suites.

This will automagically affect all our servers that use this library.  Right now, this is only `nion`.