### PR TITLE
basic API around application shutdown

### DIFF
--- a/arrangehttp/server_test.go
+++ b/arrangehttp/server_test.go
@@ -214,7 +214,13 @@ func (suite *ServerSuite) testBindServerNoTLS() {
 		fx.Invoke(
 			fx.Annotate(
 				BindServer,
-				arrange.Tags().Skip().Skip().Group("listener.middleware").ParamTags(),
+				arrange.Tags().
+					Skip().
+					Skip().
+					Skip().
+					Skip().
+					Group("listener.middleware").
+					ParamTags(),
 			),
 		),
 	)

--- a/exitCoder.go
+++ b/exitCoder.go
@@ -1,0 +1,74 @@
+package arrange
+
+import "errors"
+
+// DefaultErrorExitCode is used when no exit code could otherwise be
+// determined for a non-nil error.
+const DefaultErrorExitCode int = 1
+
+// ExitCoder is an optional interface that an error can implement to supply
+// an associated exit code with that error.  Useful particularly with fx.ExitCode
+// or to determine the process exit code upon an error.
+type ExitCoder interface {
+	// ExitCode returns the exit code associated with this error.
+	ExitCode() int
+}
+
+type exitCodeErr struct {
+	error
+	exitCode int
+}
+
+func (ece exitCodeErr) ExitCode() int {
+	return ece.exitCode
+}
+
+func (ece exitCodeErr) Unwrap() error {
+	return ece.error
+}
+
+// UseExitCode returns a new error object that associates an existing error
+// with an exit code.  The new error will implement ExitCoder and will have
+// an Unwrap method as described in the errors package.
+//
+// If err is nil, this function immediately panics so as not to delay a panic
+// until the returned error is used.
+func UseExitCode(err error, exitCode int) error {
+	if err == nil {
+		panic("cannot associate a nil error with an exit code")
+	}
+
+	return exitCodeErr{
+		error:    err,
+		exitCode: exitCode,
+	}
+}
+
+// ErrorCoder is a strategy type for determining the exit code for an error.
+// Note that this strategy will be invoked with a nil error to allow custom
+// logic for returning exit codes indicating success.
+type ErrorCoder func(error) int
+
+// ExitCodeFor provides a standard way of determining the exit code associated
+// with an error.  Logic is applied in the following order:
+//
+//   - If err implements ExitCoder, that exit code is returned
+//   - If coder is not nil, it is invoked to determine the exit code
+//   - If err is not nil, DefaultErrorExitCode is returned
+//   - If none of the above are true, this function returns zero (0).
+func ExitCodeFor(err error, coder ErrorCoder) int {
+	var ec ExitCoder
+	switch {
+	case errors.As(err, &ec):
+		return ec.ExitCode()
+
+	case coder != nil:
+		return coder(err) // err can be nil
+
+	case err != nil:
+		return DefaultErrorExitCode
+
+	default:
+		return 0
+	}
+}

--- a/exitCoder_test.go
+++ b/exitCoder_test.go
@@ -1,0 +1,96 @@
+package arrange
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type testError struct{}
+
+func (te testError) Error() string {
+	return "test error"
+}
+
+type ExitCoderSuite struct {
+	suite.Suite
+}
+
+func (suite *ExitCoderSuite) testUseExitCodeNilError() {
+	suite.Panics(
+		func() {
+			UseExitCode(nil, 1)
+		},
+	)
+}
+
+func (suite *ExitCoderSuite) testUseExitCodeWithError() {
+	err := UseExitCode(testError{}, 123)
+	suite.Require().Error(err)
+
+	var te testError
+	suite.ErrorAs(err, &te)
+
+	var ec ExitCoder
+	suite.ErrorAs(err, &ec)
+	suite.Equal(123, ec.ExitCode())
+}
+
+func (suite *ExitCoderSuite) TestUseExitCode() {
+	suite.Run("NilError", suite.testUseExitCodeNilError)
+	suite.Run("WithError", suite.testUseExitCodeWithError)
+}
+
+func (suite *ExitCoderSuite) testExitCodeForWithExitCoder() {
+	suite.Run("NilErrorCoder", func() {
+		err := UseExitCode(testError{}, 123)
+		suite.Equal(123, ExitCodeFor(err, nil))
+	})
+
+	suite.Run("WithErrorCoder", func() {
+		err := UseExitCode(testError{}, 123)
+		suite.Equal(123, ExitCodeFor(err, func(error) int { return 255 }))
+	})
+}
+
+func (suite *ExitCoderSuite) testExitCodeForNonExitCoder() {
+	suite.Run("NilErrorCoder", func() {
+		suite.Equal(
+			DefaultErrorExitCode,
+			ExitCodeFor(testError{}, nil),
+		)
+	})
+
+	suite.Run("WithErrorCoder", func() {
+		suite.Equal(
+			255,
+			ExitCodeFor(testError{}, func(error) int { return 255 }),
+		)
+	})
+}
+
+func (suite *ExitCoderSuite) testExitCodeForNilError() {
+	suite.Run("NilErrorCoder", func() {
+		suite.Equal(0, ExitCodeFor(nil, nil))
+	})
+
+	suite.Run("WithErrorCoder", func() {
+		suite.Equal(
+			255,
+			ExitCodeFor(nil, func(v error) int {
+				suite.NoError(v)
+				return 255
+			}),
+		)
+	})
+}
+
+func (suite *ExitCoderSuite) TestExitCodeFor() {
+	suite.Run("WithExitCoder", suite.testExitCodeForWithExitCoder)
+	suite.Run("NonExitCoder", suite.testExitCodeForNonExitCoder)
+	suite.Run("NilError", suite.testExitCodeForNilError)
+}
+
+func TestExitCoder(t *testing.T) {
+	suite.Run(t, new(ExitCoderSuite))
+}

--- a/shutdownWhenDone.go
+++ b/shutdownWhenDone.go
@@ -1,0 +1,60 @@
+package arrange
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+)
+
+// Task is the type that any context-less operation must conform to.
+type Task interface {
+	~func() | ~func() error
+}
+
+// ShutdownWhenDone executes a context-less task and ensures that the enclosing fx.App
+// is shutdown when the task is complete.  Any error, including a nil error, from the task
+// is interpolated into an exit code via ExitCodeFor.  That exit code will be available
+// in the fx.ShutdownSignal.
+func ShutdownWhenDone[T Task](sh fx.Shutdowner, coder ErrorCoder, task T) (err error) {
+	defer func() {
+		sh.Shutdown(
+			fx.ExitCode(
+				ExitCodeFor(err, coder),
+			),
+		)
+	}()
+
+	if t, ok := any(task).(func()); ok {
+		t()
+	} else {
+		err = any(task).(func() error)()
+	}
+
+	return
+}
+
+// TaskCtx is the type that any operation that requires a context must conform to.
+type TaskCtx interface {
+	~func(context.Context) | ~func(context.Context) error
+}
+
+// ShutdownWhenDoneCtx executes a context-based task and ensures that the enclosing fx.App
+// is shutdown when the task is complete.  This function is like ShutdownWhenDone, but for use
+// when a context.Context is needed.
+func ShutdownWhenDoneCtx[T TaskCtx](ctx context.Context, sh fx.Shutdowner, coder ErrorCoder, task T) (err error) {
+	defer func() {
+		sh.Shutdown(
+			fx.ExitCode(
+				ExitCodeFor(err, coder),
+			),
+		)
+	}()
+
+	if t, ok := any(task).(func(context.Context)); ok {
+		t(ctx)
+	} else {
+		err = any(task).(func(context.Context) error)(ctx)
+	}
+
+	return
+}

--- a/shutdownWhenDone_test.go
+++ b/shutdownWhenDone_test.go
@@ -1,0 +1,168 @@
+package arrange
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/xmidt-org/arrange/arrangetest"
+	"go.uber.org/fx"
+)
+
+type ShutdownWhenDoneSuite struct {
+	suite.Suite
+}
+
+func (suite *ShutdownWhenDoneSuite) testShutdownWhenDoneNoError() {
+	var (
+		control = make(chan struct{})
+		app     = arrangetest.NewApp(
+			suite,
+			fx.Invoke(
+				func(sh fx.Shutdowner) {
+					go ShutdownWhenDone(
+						sh,
+						func(err error) int {
+							suite.NoError(err)
+							return 123
+						},
+						func() {
+							<-control
+						},
+					)
+				},
+			),
+		)
+	)
+
+	app.RequireStart()
+	close(control)
+	select {
+	case sig := <-app.Wait():
+		suite.Equal(123, sig.ExitCode)
+	case <-time.After(time.Second):
+		suite.Fail("did not receive shutdown signal")
+	}
+}
+
+func (suite *ShutdownWhenDoneSuite) testShutdownWhenDoneWithError() {
+	var (
+		expectedErr = errors.New("expected")
+		control     = make(chan struct{})
+		app         = arrangetest.NewApp(
+			suite,
+			fx.Invoke(
+				func(sh fx.Shutdowner) {
+					go ShutdownWhenDone(
+						sh,
+						func(err error) int {
+							suite.Same(expectedErr, err)
+							return 123
+						},
+						func() error {
+							<-control
+							return expectedErr
+						},
+					)
+				},
+			),
+		)
+	)
+
+	app.RequireStart()
+	close(control)
+	select {
+	case sig := <-app.Wait():
+		suite.Equal(123, sig.ExitCode)
+	case <-time.After(time.Second):
+		suite.Fail("did not receive shutdown signal")
+	}
+}
+
+func (suite *ShutdownWhenDoneSuite) TestShutdownWhenDone() {
+	suite.Run("NoError", suite.testShutdownWhenDoneNoError)
+	suite.Run("WithError", suite.testShutdownWhenDoneWithError)
+}
+
+func (suite *ShutdownWhenDoneSuite) testShutdownWhenDoneCtxNoError() {
+	var (
+		expectedCtx = context.WithValue(context.Background(), "foo", "bar")
+		control     = make(chan struct{})
+		app         = arrangetest.NewApp(
+			suite,
+			fx.Invoke(
+				func(sh fx.Shutdowner) {
+					go ShutdownWhenDoneCtx(
+						expectedCtx,
+						sh,
+						func(err error) int {
+							suite.NoError(err)
+							return 123
+						},
+						func(ctx context.Context) {
+							suite.Same(expectedCtx, ctx)
+							<-control
+						},
+					)
+				},
+			),
+		)
+	)
+
+	app.RequireStart()
+	close(control)
+	select {
+	case sig := <-app.Wait():
+		suite.Equal(123, sig.ExitCode)
+	case <-time.After(time.Second):
+		suite.Fail("did not receive shutdown signal")
+	}
+}
+
+func (suite *ShutdownWhenDoneSuite) testShutdownWhenDoneCtxWithError() {
+	var (
+		expectedCtx = context.WithValue(context.Background(), "foo", "bar")
+		expectedErr = errors.New("expected")
+		control     = make(chan struct{})
+		app         = arrangetest.NewApp(
+			suite,
+			fx.Invoke(
+				func(sh fx.Shutdowner) {
+					go ShutdownWhenDoneCtx(
+						expectedCtx,
+						sh,
+						func(err error) int {
+							suite.Same(expectedErr, err)
+							return 123
+						},
+						func(ctx context.Context) error {
+							suite.Same(expectedCtx, ctx)
+							<-control
+							return expectedErr
+						},
+					)
+				},
+			),
+		)
+	)
+
+	app.RequireStart()
+	close(control)
+	select {
+	case sig := <-app.Wait():
+		suite.Equal(123, sig.ExitCode)
+	case <-time.After(time.Second):
+		suite.Fail("did not receive shutdown signal")
+	}
+}
+
+func (suite *ShutdownWhenDoneSuite) TestShutdownWhenDoneCtx() {
+	suite.Run("NoError", suite.testShutdownWhenDoneCtxNoError)
+	suite.Run("WithError", suite.testShutdownWhenDoneCtxWithError)
+}
+
+func TestShutdownWhenDone(t *testing.T) {
+	suite.Run(t, new(ShutdownWhenDoneSuite))
+}


### PR DESCRIPTION
Since this comes up so often, factoring out the `arrangehttp` package's logic to ensure the enclosing fx.App is properly shutdown when a longrunning task (e.g. running a server) completes, either due to an error or just in normal execution.