### PR TITLE
Feature/move lifecycle into provide

### DIFF
--- a/arrangehttp/listener_test.go
+++ b/arrangehttp/listener_test.go
@@ -90,8 +90,7 @@ func (suite *ListenerSuite) testNewListenerNilListenerFactory() {
 	suite.Require().NoError(err)
 	suite.Require().NotNil(l)
 	defer l.Close()
-	actual, ok := arrangetest.ListenReceive(capture, time.Second)
-	suite.True(ok)
+	actual := arrangetest.ListenReceive(suite, capture, time.Second)
 	suite.Equal(l.Addr(), actual)
 }
 
@@ -111,8 +110,7 @@ func (suite *ListenerSuite) testNewListenerCustomListenerFactory() {
 	suite.Require().NoError(err)
 	suite.Require().NotNil(l)
 	defer l.Close()
-	actual, ok := arrangetest.ListenReceive(capture, time.Second)
-	suite.True(ok)
+	actual := arrangetest.ListenReceive(suite, capture, time.Second)
 	suite.Equal(l.Addr(), actual)
 }
 

--- a/arrangehttp/server.go
+++ b/arrangehttp/server.go
@@ -88,7 +88,7 @@ func newServerProvider[H http.Handler, F ServerFactory](serverName string, exter
 	for _, e := range external {
 		if o, ok := e.(Option[http.Server]); ok {
 			sp.options = append(sp.options, o)
-		} else if lm, ok := e.(ListenerMiddleware); ok {
+		} else if lm, ok := e.(func(net.Listener) net.Listener); ok {
 			sp.listenerMiddleware = append(sp.listenerMiddleware, lm)
 		} else {
 			err = multierr.Append(err, fmt.Errorf("%T is not a valid external server option", e))

--- a/arrangehttp/server.go
+++ b/arrangehttp/server.go
@@ -3,12 +3,14 @@ package arrangehttp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 
 	"github.com/xmidt-org/arrange"
 	"github.com/xmidt-org/arrange/internal/arrangereflect"
 	"go.uber.org/fx"
+	"go.uber.org/multierr"
 )
 
 const (
@@ -49,7 +51,7 @@ func NewServer(sc ServerConfig, h http.Handler, opts ...Option[http.Server]) (*h
 //
 // The ServerFactory may also optionally implement Option[http.Server].  If it does, the factory
 // option is applied after all other options have run.
-func NewServerCustom[F ServerFactory, H http.Handler](sf F, h H, opts ...Option[http.Server]) (s *http.Server, err error) {
+func NewServerCustom[H http.Handler, F ServerFactory](sf F, h H, opts ...Option[http.Server]) (s *http.Server, err error) {
 	s, err = sf.NewServer()
 	if err == nil {
 		s.Handler = arrangereflect.Safe[http.Handler](h, http.DefaultServeMux)
@@ -64,6 +66,93 @@ func NewServerCustom[F ServerFactory, H http.Handler](sf F, h H, opts ...Option[
 	return
 }
 
+// serverProvider is an internal strategy for managing a server's lifecycle within an
+// enclosing fx.App.
+type serverProvider[H http.Handler, F ServerFactory] struct {
+	serverName string
+
+	// options are the externally supplied options.  These are not injected, but are
+	// supplied via the ProvideXXX call.
+	options []Option[http.Server]
+
+	// listenerMiddleware are the externally supplied listener middleware.  Similar to options.
+	listenerMiddleware []ListenerMiddleware
+}
+
+func newServerProvider[H http.Handler, F ServerFactory](serverName string, external ...any) (sp serverProvider[H, F], err error) {
+	sp.serverName = serverName
+	if len(sp.serverName) == 0 {
+		err = multierr.Append(err, ErrServerNameRequired)
+	}
+
+	for _, e := range external {
+		if o, ok := e.(Option[http.Server]); ok {
+			sp.options = append(sp.options, o)
+		} else if lm, ok := e.(ListenerMiddleware); ok {
+			sp.listenerMiddleware = append(sp.listenerMiddleware, lm)
+		} else {
+			err = multierr.Append(err, fmt.Errorf("%T is not a valid external server option", e))
+		}
+	}
+
+	return
+}
+
+// newServer is the server constructor function.
+func (sp serverProvider[H, F]) newServer(sf F, h H, injected ...Option[http.Server]) (s *http.Server, err error) {
+	s, err = NewServerCustom[H, F](sf, h, injected...)
+	if err == nil {
+		s, err = ApplyOptions(s, sp.options...)
+	}
+
+	return
+}
+
+// newListener creates a net.Listener for a given *http.Server.
+func (sp serverProvider[H, F]) newListener(ctx context.Context, sf F, s *http.Server, injected ...ListenerMiddleware) (l net.Listener, err error) {
+	l, err = NewListener(ctx, sf, s, injected...)
+	if err == nil {
+		l = ApplyMiddleware(l, sp.listenerMiddleware...)
+	}
+
+	return
+}
+
+// runServer starts the server and ensures that the enclosing fx.App is shutdown no matter
+// how the server terminates.
+func (sp serverProvider[H, F]) runServer(sh fx.Shutdowner, s *http.Server, l net.Listener) {
+	go arrange.ShutdownWhenDone(
+		sh,
+		// TODO: make the error coder configurable somehow
+		func(err error) int {
+			if !errors.Is(err, http.ErrServerClosed) {
+				return ServerAbnormalExitCode
+			}
+
+			return 0
+		},
+		func() error {
+			return s.Serve(l)
+		},
+	)
+}
+
+// bindServer binds a server to the lifecycle of an enclosing fx.App.
+func (sp serverProvider[H, F]) bindServer(sf F, s *http.Server, lc fx.Lifecycle, sh fx.Shutdowner, injected ...ListenerMiddleware) {
+	lc.Append(fx.StartStopHook(
+		func(ctx context.Context) (err error) {
+			var l net.Listener
+			l, err = sp.newListener(ctx, sf, s, injected...)
+			if err == nil {
+				sp.runServer(sh, s, l)
+			}
+
+			return
+		},
+		s.Shutdown,
+	))
+}
+
 // ProvideServer assembles a server out of application components in a standard, opinionated way.
 // The serverName parameter is used as both the name of the *http.Server component and a prefix
 // for that server's dependencies:
@@ -72,143 +161,46 @@ func NewServerCustom[F ServerFactory, H http.Handler](sf F, h H, opts ...Option[
 //   - ServerConfig is an optional dependency with the name serverName+".config"
 //   - http.Handler is an optional dependency with the name serverName+".handler"
 //   - []Option[http.Server] is a value group dependency with the name serverName+".options"
+//   - []ListenerMiddleware is a value group dependency with the name serverName+".listener.middleware"
 //
-// The external set of options, if supplied, is applied to the server after any injected options.
-// This allows for options that come from outside the enclosing fx.App, as might be the case
-// for options driven by the command line.
-func ProvideServer(serverName string, external ...Option[http.Server]) fx.Option {
-	return ProvideServerCustom[ServerConfig, http.Handler](serverName, external...)
+// The external slice contains items that come from outside the enclosing fx.App that are applied to
+// the server and listener.  Each element of external must be either an Option[http.Server] or a
+// ListenerMiddleware.  Any other type short circuits application startup with an error.
+func ProvideServer(serverName string, external ...any) fx.Option {
+	return ProvideServerCustom[http.Handler, ServerConfig](serverName, external...)
 }
 
 // ProvideServerCustom is like ProvideServer, but it allows customization of the concrete
 // ServerFactory and http.Handler dependencies.
-//
-// If the concrete ServerFactory type also implements ListenerFactory, it is used to create
-// the net.Listener for the server.  Otherwise, DefaultListenerFactory is used.
-func ProvideServerCustom[F ServerFactory, H http.Handler](serverName string, external ...Option[http.Server]) fx.Option {
-	if len(serverName) == 0 {
-		return fx.Error(ErrServerNameRequired)
+func ProvideServerCustom[H http.Handler, F ServerFactory](serverName string, external ...any) fx.Option {
+	sp, err := newServerProvider[H, F](serverName, external...)
+	if err != nil {
+		return fx.Error(err)
 	}
 
-	// Use the named constructor function when possible so that uber/fx's error reporting
-	// will call out that function in logs.
-	ctor := NewServerCustom[F, H]
-	if len(external) > 0 {
-		ctor = func(sf F, h H, injected ...Option[http.Server]) (s *http.Server, err error) {
-			s, err = NewServerCustom(sf, h, injected...)
-			if err == nil {
-				s, err = ApplyOptions(s, external...)
-			}
-
-			return
-		}
-	}
-
-	return fx.Provide(
-		fx.Annotate(
-			ctor,
-			arrange.Tags().Push(serverName).
-				OptionalName("config").
-				OptionalName("handler").
-				Group("options").
-				ParamTags(),
-			arrange.Tags().Name(serverName).ResultTags(),
+	return fx.Options(
+		fx.Provide(
+			fx.Annotate(
+				sp.newServer,
+				arrange.Tags().Push(serverName).
+					OptionalName("config").
+					OptionalName("handler").
+					Group("options").
+					ParamTags(),
+				arrange.Tags().Name(serverName).ResultTags(),
+			),
 		),
-	)
-}
-
-// BindServer binds a server to the enclosing application's lifecycle.  The ServerConfig, acting as a
-// ListenerFactory, is used to create the listener.  Middleware is applied to this listener before
-// calling http.Server.Serve.
-//
-// The server is shutdown gracefully via http.Server.Shutdown.
-//
-// InvokeServer provides an opinionated way to use this function.  However, this function can be
-// used with fx.Invoke directly to allow very flexible ways of binding a server:
-//
-//	app := fx.New(
-//	  fx.Invoke(
-//	    arrangehttp.BindServer, // all the parameters need to be global
-//	    fx.Annotate(
-//	      arrangehttp.BindServer,
-//	      fx.ParamTags(
-//	        "", // the ServerConfig is a global component
-//	        `name:"myserver"`, // the name of the *http.Server being bound
-//	      ),
-//	    ),
-//	  ),
-//	)
-func BindServer(cfg ServerConfig, server *http.Server, lifecycle fx.Lifecycle, shutdowner fx.Shutdowner, lm ...ListenerMiddleware) {
-	BindServerCustom(cfg, server, lifecycle, shutdowner, lm...)
-}
-
-// BindServerCustom is like BindServer, but allows injection of a different concrete type for the ListenerFactory.
-func BindServerCustom[F ListenerFactory](cfg F, server *http.Server, lifecycle fx.Lifecycle, shutdowner fx.Shutdowner, lm ...ListenerMiddleware) {
-	lifecycle.Append(
-		fx.StartStopHook(
-			func(ctx context.Context) (err error) {
-				var l net.Listener
-				l, err = NewListener(ctx, cfg, server, lm...)
-				if err == nil {
-					go func() {
-						var exitCode int
-						defer func() {
-							shutdowner.Shutdown(
-								fx.ExitCode(exitCode),
-							)
-						}()
-
-						serveErr := server.Serve(l)
-						if !errors.Is(serveErr, http.ErrServerClosed) {
-							exitCode = ServerAbnormalExitCode
-						}
-					}()
-				}
-
-				return
-			},
-			server.Shutdown,
-		),
-	)
-}
-
-// InvokeServer produces an fx.Invoke that binds a server to the application's lifecycle.
-// This function uses BindServer, with the following dependencies:
-//
-//   - ServerConfig as an optional dependency with the name serverName+".config".  This is used as the listener factory.
-//   - *http.Server as a required dependency named serverName.  This is typically the component created by NewServer or NewServerCustom.
-//   - []ListenerMiddleware as a value group named serverName+".listener.middleware".  These injected middleware are executed after the external middleware.
-func InvokeServer(serverName string, external ...ListenerMiddleware) fx.Option {
-	return InvokeServerCustom[ServerConfig](serverName, external...)
-}
-
-// InvokeServerCustom is like InvokeServer, but allows customization of the concrete ListenerFactory implementation.
-// Useful when you have a custom configuration object different from ServerConfig.
-func InvokeServerCustom[F ListenerFactory](serverName string, external ...ListenerMiddleware) fx.Option {
-	if len(serverName) == 0 {
-		return fx.Error(ErrServerNameRequired)
-	}
-
-	invoke := BindServerCustom[F]
-	if len(external) > 0 {
-		invoke = func(lf F, server *http.Server, lifecycle fx.Lifecycle, shutdowner fx.Shutdowner, injected ...ListenerMiddleware) {
-			m := make([]ListenerMiddleware, 0, len(injected)+len(external))
-			m = append(m, external...) // external middleware will execute first, before injected
-			m = append(m, injected...)
-			BindServerCustom(lf, server, lifecycle, shutdowner, m...)
-		}
-	}
-
-	return fx.Invoke(
-		fx.Annotate(
-			invoke,
-			arrange.Tags().Push(serverName).
-				OptionalName("config").
-				Push("").Name(serverName).Pop().
-				Skip().
-				Skip().
-				Group("listener.middleware").
-				ParamTags(),
+		fx.Invoke(
+			fx.Annotate(
+				sp.bindServer,
+				arrange.Tags().Push(serverName).
+					OptionalName("config").
+					Push("").Name(serverName).Pop().
+					Skip().
+					Skip().
+					Group("listener.middleware").
+					ParamTags(),
+			),
 		),
 	)
 }

--- a/arrangehttp/serverFactory.go
+++ b/arrangehttp/serverFactory.go
@@ -12,13 +12,15 @@ import (
 	"github.com/xmidt-org/httpaux/server"
 )
 
-// ServerFactory is the strategy for instantiating an *http.Server.  ServerConfig is this
-// package's implementation of this interface, and allows a ServerFactory instance to be
-// read from an external source.
+// ServerFactory is the strategy for instantiating an *http.Server and an associated net.Listener.
+// ServerConfig is this package's implementation of this interface, and allows a ServerFactory instance
+// to be read from an external source.
 //
 // A custom ServerFactory implementation can be injected and used via NewServerCustom
 // or ProvideServerCustom.
 type ServerFactory interface {
+	ListenerFactory
+
 	// NewServer constructs an *http.Server.
 	NewServer() (*http.Server, error)
 }

--- a/arrangehttp/server_test.go
+++ b/arrangehttp/server_test.go
@@ -1,7 +1,6 @@
 package arrangehttp
 
 import (
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -191,49 +190,6 @@ func (suite *ServerSuite) TestProvideServer() {
 	suite.Run("NoName", suite.testProvideServerNoName)
 	suite.Run("Simple", suite.testProvideServerSimple)
 	suite.Run("Full", suite.testProvideServerFull)
-}
-
-func (suite *ServerSuite) testBindServerNoTLS() {
-	ch := make(chan net.Addr, 1)
-	app := arrangetest.NewApp(
-		suite,
-		fx.Supply(
-			ServerConfig{},
-			&http.Server{
-				Addr: ":0",
-			},
-		),
-		fx.Provide(
-			fx.Annotate(
-				func() ListenerMiddleware {
-					return arrangetest.ListenCapture(ch)
-				},
-				arrange.Tags().Group("listener.middleware").ResultTags(),
-			),
-		),
-		fx.Invoke(
-			fx.Annotate(
-				BindServer,
-				arrange.Tags().
-					Skip().
-					Skip().
-					Skip().
-					Skip().
-					Group("listener.middleware").
-					ParamTags(),
-			),
-		),
-	)
-
-	app.RequireStart()
-	_, ok := arrangetest.ListenReceive(ch, 2*time.Second)
-	suite.True(ok)
-
-	app.RequireStop()
-}
-
-func (suite *ServerSuite) TestBindServer() {
-	suite.Run("NoTLS", suite.testBindServerNoTLS)
 }
 
 func TestServer(t *testing.T) {

--- a/arrangetest/app.go
+++ b/arrangetest/app.go
@@ -1,33 +1,10 @@
 package arrangetest
 
 import (
-	"fmt"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 )
-
-// tb is a helper function that extracts the fxtest.TB from a value.  The value
-// may supply a T() *testing.T as a layer of indirection, or it can be a *testing.T
-// or *testing.B.
-func tb(v any) fxtest.TB {
-	type testHolder interface {
-		T() *testing.T
-	}
-
-	switch vv := v.(type) {
-	case testHolder:
-		return vv.T()
-
-	case fxtest.TB:
-		return vv
-
-	default:
-		panic(fmt.Errorf("%T is not a valid test object", v))
-	}
-}
 
 // NewApp creates an *fxtest.App using the enclosing test.
 //
@@ -35,7 +12,7 @@ func tb(v any) fxtest.TB {
 // a stretchr test suite.  Or, it may implement fxtest.TB directly, as is
 // the case with *testing.T and *testing.B.
 func NewApp(t any, o ...fx.Option) *fxtest.App {
-	return fxtest.New(tb(t), o...)
+	return fxtest.New(AsTestable(t), o...)
 }
 
 // NewErrApp creates an *fx.App which is expected to fail during construction.
@@ -52,6 +29,6 @@ func NewErrApp(t any, o ...fx.Option) *fx.App {
 		)...,
 	)
 
-	assert.Error(tb(t), app.Err())
+	assert.Error(AsTestable(t), app.Err())
 	return app
 }

--- a/arrangetest/app_test.go
+++ b/arrangetest/app_test.go
@@ -57,12 +57,12 @@ func (suite *AppSuite) testNewErrAppSuccess() {
 }
 
 func (suite *AppSuite) testNewErrAppFail() {
-	mockTB := new(mockTB)
-	mockTB.ExpectAnyErrorf()
+	mockT := new(mockTestable)
+	mockT.ExpectAnyErrorf()
 
-	NewErrApp(mockTB) // no error should cause an assert failure, which is a success for this test
+	NewErrApp(mockT) // no error should cause an assert failure, which is a success for this test
 
-	mockTB.AssertExpectations(suite.T())
+	mockT.AssertExpectations(suite.T())
 }
 
 func (suite *AppSuite) TestNewErrApp() {

--- a/arrangetest/listenCapture_test.go
+++ b/arrangetest/listenCapture_test.go
@@ -44,26 +44,27 @@ func (suite *ListenSuite) testListenReceiveSuccess() {
 	)
 
 	ch <- expected // won't block, buffer size is 1
-	actual, ok := ListenReceive(ch, time.Second)
-	suite.True(ok)
+	actual := ListenReceive(suite, ch, time.Second)
 	suite.Same(expected, actual)
 }
 
-func (suite *ListenSuite) testListenReceiveTimeout() {
+func (suite *ListenSuite) testListenReceiveFail() {
 	var (
-		ch = make(chan net.Addr, 1)
-		t  = make(chan time.Time, 1)
+		mockT = new(mockTestable)
+		ch    = make(chan net.Addr, 1)
 	)
 
-	t <- time.Now() // won't block, buffer size is 1
-	actual, ok := listenReceive(ch, t)
-	suite.False(ok)
+	mockT.ExpectAnyErrorf()
+	mockT.ExpectFailNow()
+
+	actual := ListenReceive(mockT, ch, time.Millisecond)
 	suite.Nil(actual)
+	mockT.AssertExpectations(suite.T())
 }
 
 func (suite *ListenSuite) TestListenReceive() {
 	suite.Run("Success", suite.testListenReceiveSuccess)
-	suite.Run("Timeout", suite.testListenReceiveTimeout)
+	suite.Run("Fail", suite.testListenReceiveFail)
 }
 
 func TestListen(t *testing.T) {

--- a/arrangetest/mocks_test.go
+++ b/arrangetest/mocks_test.go
@@ -2,15 +2,15 @@ package arrangetest
 
 import "github.com/stretchr/testify/mock"
 
-type mockTB struct {
+type mockTestable struct {
 	mock.Mock
 }
 
-func (m *mockTB) Logf(format string, args ...any) {
+func (m *mockTestable) Logf(format string, args ...any) {
 	m.Called(format, args)
 }
 
-func (m *mockTB) ExpectAnyLogf() *mock.Call {
+func (m *mockTestable) ExpectAnyLogf() *mock.Call {
 	return m.On(
 		"Logf",
 		mock.AnythingOfType("string"),
@@ -18,11 +18,11 @@ func (m *mockTB) ExpectAnyLogf() *mock.Call {
 	)
 }
 
-func (m *mockTB) Errorf(format string, args ...any) {
+func (m *mockTestable) Errorf(format string, args ...any) {
 	m.Called(format, args)
 }
 
-func (m *mockTB) ExpectAnyErrorf() *mock.Call {
+func (m *mockTestable) ExpectAnyErrorf() *mock.Call {
 	return m.On(
 		"Errorf",
 		mock.AnythingOfType("string"),
@@ -30,10 +30,10 @@ func (m *mockTB) ExpectAnyErrorf() *mock.Call {
 	)
 }
 
-func (m *mockTB) FailNow() {
+func (m *mockTestable) FailNow() {
 	m.Called()
 }
 
-func (m *mockTB) ExpectFailNow() *mock.Call {
+func (m *mockTestable) ExpectFailNow() *mock.Call {
 	return m.On("FailNow")
 }

--- a/arrangetest/testable.go
+++ b/arrangetest/testable.go
@@ -1,0 +1,34 @@
+package arrangetest
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Testable is the minimal interface required for assertions and testing.
+// This interface is implemented by several libraries.
+type Testable interface {
+	Logf(string, ...interface{})
+	Errorf(string, ...interface{})
+	FailNow()
+}
+
+// AsTestable converts a value into a Testable.  The v parameter
+// may be a *testing.T, *testing.B, or a type that provides a T() *testing.T method.
+//
+// If v cannot be coerced into a Testable, this function panics.
+func AsTestable(v any) Testable {
+	if tt, ok := v.(Testable); ok {
+		return tt
+	}
+
+	type testHolder interface {
+		T() *testing.T
+	}
+
+	if th, ok := v.(testHolder); ok {
+		return th.T()
+	}
+
+	panic(fmt.Errorf("%T cannot be converted into a Testable", v))
+}

--- a/arrangetest/testable_test.go
+++ b/arrangetest/testable_test.go
@@ -1,0 +1,39 @@
+package arrangetest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TestableSuite struct {
+	suite.Suite
+}
+
+func (suite *TestableSuite) testAsTestableInvalidValue() {
+	suite.Panics(func() {
+		AsTestable(123)
+	})
+}
+
+func (suite *TestableSuite) testAsTestableWithSuite() {
+	suite.NotNil(
+		AsTestable(suite),
+	)
+}
+
+func (suite *TestableSuite) testAsTestableWithTestingT() {
+	suite.NotNil(
+		AsTestable(suite.T()),
+	)
+}
+
+func (suite *TestableSuite) TestAsTestable() {
+	suite.Run("InvalidValue", suite.testAsTestableInvalidValue)
+	suite.Run("WithSuite", suite.testAsTestableWithSuite)
+	suite.Run("WithTestingT", suite.testAsTestableWithTestingT)
+}
+
+func TestTestable(t *testing.T) {
+	suite.Run(t, new(TestableSuite))
+}

--- a/shutdownWhenDone_test.go
+++ b/shutdownWhenDone_test.go
@@ -87,8 +87,10 @@ func (suite *ShutdownWhenDoneSuite) TestShutdownWhenDone() {
 }
 
 func (suite *ShutdownWhenDoneSuite) testShutdownWhenDoneCtxNoError() {
+	type contextKey struct{}
+
 	var (
-		expectedCtx = context.WithValue(context.Background(), "foo", "bar")
+		expectedCtx = context.WithValue(context.Background(), contextKey{}, "bar")
 		control     = make(chan struct{})
 		app         = arrangetest.NewApp(
 			suite,
@@ -122,8 +124,10 @@ func (suite *ShutdownWhenDoneSuite) testShutdownWhenDoneCtxNoError() {
 }
 
 func (suite *ShutdownWhenDoneSuite) testShutdownWhenDoneCtxWithError() {
+	type contextKey struct{}
+
 	var (
-		expectedCtx = context.WithValue(context.Background(), "foo", "bar")
+		expectedCtx = context.WithValue(context.Background(), contextKey{}, "bar")
 		expectedErr = errors.New("expected")
 		control     = make(chan struct{})
 		app         = arrangetest.NewApp(


### PR DESCRIPTION
## Work in progress:

Refactored the server provide functions for simplicity:  `ProvideServer` and `ProvideServerCustom` now handle the lifecycle as well as the construction of an *http.Server.

I also changed the order of generic parameters to take advantage of interpolation.  This makes it easy to change the type of injected `http.Handler` while still using `arrangehttp.ServerConfig` as the unmarshaled configuration object, which is the common case.  As an example:  `arrangehttp.ProvideServerCustom[MyHandler]` is less noisy than `arrangehttp.ProvideServerCustom[arrangehttp.ServerConfig, MyHandler]` when all you want to do is inject a different concrete type of handler.