### PR TITLE
Feature/pprof use servemux

### DIFF
--- a/arrangepprof/http.go
+++ b/arrangepprof/http.go
@@ -1,128 +1,50 @@
 package arrangepprof
 
 import (
+	"net/http"
 	"net/http/pprof"
-	"reflect"
-	rpprof "runtime/pprof"
-
-	"github.com/gorilla/mux"
-	"go.uber.org/fx"
+	"path"
 )
 
 // DefaultPathPrefix is used as the path prefix for HTTP pprof handlers
-// when no HTTPRoutes.PathPrefix field is supplied
+// when no HTTP.PathPrefix field is supplied
 const DefaultPathPrefix = "/debug/pprof"
 
-// ConfigureRoutes adds the various pprof routes to a *mux.Router.  This
-// function can be used as a standalone mechanism for adding pprof routes
-// to any router.
-//
-// The typical way to use this function is to call it against a Subrouter, e.g.:
-//
-//	ConfigureRoutes(router.PathPrefix("/foo/").Subrouter())
-//
-// NOTE: This method does not do the special mapping for pprof.Index for
-// a path prefix with no trailing slash, e.g. "/debug/pprof".  Callers will
-// need to implement that.  HTTP.Provide handles that case.
-func ConfigureRoutes(r *mux.Router) {
-	r.Path("/").HandlerFunc(pprof.Index)
-	r.Path("/cmdline").HandlerFunc(pprof.Cmdline)
-	r.Path("/profile").HandlerFunc(pprof.Profile)
-	r.Path("/symbol").HandlerFunc(pprof.Symbol)
-	r.Path("/trace").HandlerFunc(pprof.Trace)
-
-	// NOTE: have to add each profile separately, as gorilla/mux has
-	// stricter matching and net/http.ServeMux
-	for _, p := range rpprof.Profiles() {
-		r.Path("/" + p.Name()).HandlerFunc(pprof.Index)
-	}
-}
-
-// HTTP is the strategy for attaching pprof routes to an injected *mux.Router
+// HTTP is the strategy for attaching pprof routes to an arbitrary *http.ServeMux.
 type HTTP struct {
 	// PathPrefix is the prefix URL for all the pprof routes.  If unset,
 	// DefaultPathPrefix is used instead.  To bind the pprof routes to the
 	// root URL, set this field to "/".
 	PathPrefix string
-
-	// RouterName is the fx.App component name of the *mux.Router.  If this field
-	// is unset, then an unnamed, global *mux.Router is assumed.
-	//
-	// Set this field when multiple http.Server instances are used within
-	// the same fx.App.
-	RouterName string
 }
 
-// buildRouterIn dynamically builds an fx.In struct for Provide.
-// The first two fields will the fx.In and the optional fx.Printer.
-// The *mux.Router field will immediately follow those two.
-func (hr *HTTP) buildRouterIn() reflect.Type {
-	fields := []reflect.StructField{
-		{
-			Name:      "In",
-			Type:      reflect.TypeOf(fx.In{}),
-			Anonymous: true,
-		},
-		{
-			Name: "Router",
-			Type: reflect.TypeOf((*mux.Router)(nil)),
-		},
-	}
-
-	if len(hr.RouterName) > 0 {
-		fields[1].Tag = reflect.StructTag(`name:"` + hr.RouterName + `"`)
-	}
-
-	return reflect.StructOf(fields)
+// New constructs an *http.ServeMux with pprof routes configured.  This method
+// can be passed to provide and annotated.
+func (h HTTP) New() *http.ServeMux {
+	mux := http.NewServeMux()
+	return h.Apply(mux)
 }
 
-// invokeFuncOf dynamically produces the function type for the fx.Invoke
-// function that configures pprof routes
-func (hr *HTTP) invokeFuncOf() reflect.Type {
-	return reflect.FuncOf(
-		// in
-		[]reflect.Type{hr.buildRouterIn()},
-
-		// out
-		[]reflect.Type{},
-
-		// not variadic
-		false,
-	)
-}
-
-// invoke is the implementation of the signature returned by invokeFuncOf
-func (hr *HTTP) invoke(args []reflect.Value) []reflect.Value {
-	var (
-		in = args[0]
-
-		r = in.Field(1).Interface().(*mux.Router)
-
-		prefix = hr.PathPrefix
-	)
-
+// Apply configures the pprof routes on an existing *http.ServeMux.  This method
+// is primarily useful as an fx decorator.
+func (h HTTP) Apply(mux *http.ServeMux) *http.ServeMux {
+	prefix := h.PathPrefix
 	if len(prefix) == 0 {
 		prefix = DefaultPathPrefix
 	}
 
-	// strip trailing slashes to normalize the prefix
-	for prefix[len(prefix)-1] == '/' {
-		prefix = prefix[0 : len(prefix)-1]
+	// special processing for the index handler:
+	// register both a path with and without the trailing /
+	indexPath := path.Join(prefix, "/")
+	mux.HandleFunc(indexPath, pprof.Index)
+	if indexPath[len(indexPath)-1] != '/' {
+		mux.HandleFunc(indexPath+"/", pprof.Index)
 	}
 
-	// NOTE: this works if prefix was "/", as mapping to "" is valid
-	r.HandleFunc(prefix, pprof.Index)
-	ConfigureRoutes(r.PathPrefix(prefix + "/").Subrouter())
-	return nil
-}
+	mux.HandleFunc(path.Join(prefix, "/cmdline"), pprof.Cmdline)
+	mux.HandleFunc(path.Join(prefix, "/profile"), pprof.Profile)
+	mux.HandleFunc(path.Join(prefix, "/symbol"), pprof.Symbol)
+	mux.HandleFunc(path.Join(prefix, "/trace"), pprof.Trace)
 
-// Provide returns an fx.Option that configures the net/http/pprof handlers
-// for an injected *mux.Router
-func (hr HTTP) Provide() fx.Option {
-	return fx.Invoke(
-		reflect.MakeFunc(
-			hr.invokeFuncOf(),
-			hr.invoke,
-		).Interface(),
-	)
+	return mux
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/xmidt-org/arrange
 go 1.19
 
 require (
-	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.8.4
 	github.com/xmidt-org/httpaux v0.4.0
 	go.uber.org/fx v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
Recent news notwithstanding, I wanted to prune out any dependency on gorilla/mux.  The last holdout was the `arrangepprof` package, which I've refactored to use *http.ServeMux.  This is still compatible with other routers, since you can always just map the pprof *http.ServeMux to another router.

Let me know if we have compelling reason to keep gorilla/mux around as a dependency for `arrange`.  I have no problem continuing to use gorilla/mux, I just didn't want it to be a dependency for `arrange`.
