### PR TITLE
chore: update go version

### DIFF
--- a/arrangetls/tls_test.go
+++ b/arrangetls/tls_test.go
@@ -65,7 +65,7 @@ func testPeerVerifiersSuccess(t *testing.T) {
 		}
 	)
 
-	key, err := rsa.GenerateKey(random, 512) //nolint:gosec
+	key, err := rsa.GenerateKey(random, 1024) //nolint:gosec
 	require.NoError(err)
 
 	peerCert, err := x509.CreateCertificate(random, template, template, &key.PublicKey, key)
@@ -106,7 +106,7 @@ func testPeerVerifiersExtend(t *testing.T) {
 		}
 	)
 
-	key, err := rsa.GenerateKey(random, 512) //nolint:gosec
+	key, err := rsa.GenerateKey(random, 1024) //nolint:gosec
 	require.NoError(err)
 
 	peerCert, err := x509.CreateCertificate(random, template, template, &key.PublicKey, key)
@@ -145,7 +145,7 @@ func testPeerVerifiersFailure(t *testing.T) {
 		}
 	)
 
-	key, err := rsa.GenerateKey(random, 512) //nolint:gosec
+	key, err := rsa.GenerateKey(random, 1024) //nolint:gosec
 	require.NoError(err)
 
 	peerCert, err := x509.CreateCertificate(random, template, template, &key.PublicKey, key)
@@ -659,7 +659,7 @@ func testConfigVerifyPeerCertificate(t *testing.T) {
 		}
 	)
 
-	key, err := rsa.GenerateKey(random, 512) //nolint:gosec
+	key, err := rsa.GenerateKey(random, 1024) //nolint:gosec
 	require.NoError(err)
 
 	peerCert, err := x509.CreateCertificate(random, template, template, &key.PublicKey, key)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/xmidt-org/arrange
 
-go 1.22
-
-toolchain go1.22.5
+go 1.24
 
 require (
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
what's included:
- updated to new go version (1.24)
- update the GenerateKey function in unit tests to accept 1024 instead of 512 - as new go requires keys to be >=1024 for GenerateKey